### PR TITLE
add pbkdf2 support

### DIFF
--- a/etc/emq_auth_mysql.conf
+++ b/etc/emq_auth_mysql.conf
@@ -23,11 +23,11 @@ auth.mysql.database = mqtt
 auth.mysql.auth_query = select password from mqtt_user where username = '%u' limit 1
 
 ## Password hash: plain, md5, sha, sha256, pbkdf2
-auth.mysql.password_hash = sha256
+auth.mysql.password_hash = pbkdf2
 
 ## pbkdf2 Iterations and DerivedLength
-#auth.mysql.pbkdf2_iterations = 4096
-#auth.mysql.pbkdf2_iterations = 20
+auth.mysql.pbkdf2_iterations = 4096
+auth.mysql.pbkdf2_derivedLength = 20
 
 ## %% Superuser Query
 auth.mysql.super_query = select is_superuser from mqtt_user where username = '%u' limit 1

--- a/etc/emq_auth_mysql.conf
+++ b/etc/emq_auth_mysql.conf
@@ -25,6 +25,10 @@ auth.mysql.auth_query = select password from mqtt_user where username = '%u' lim
 ## Password hash: plain, md5, sha, sha256, pbkdf2
 auth.mysql.password_hash = sha256
 
+## pbkdf2 Iterations and DerivedLength
+#auth.mysql.pbkdf2_iterations = 4096
+#auth.mysql.pbkdf2_iterations = 20
+
 ## %% Superuser Query
 auth.mysql.super_query = select is_superuser from mqtt_user where username = '%u' limit 1
 

--- a/priv/emq_auth_mysql.schema
+++ b/priv/emq_auth_mysql.schema
@@ -54,8 +54,16 @@ end}.
 ]}.
 
 {mapping, "auth.mysql.password_hash", "emq_auth_mysql.password_hash", [
-  {default, sha256},
+  {default, pbkdf2},
   {datatype, {enum, [plain, md5, sha, sha256, pbkdf2]}}
+]}.
+
+{mapping, "auth.mysql.pbkdf2_iterations", "emq_auth_mysql.pbkdf2_iterations", [
+  {datatype, integer}
+]}.
+
+{mapping, "auth.mysql.pbkdf2_derivedLength", "emq_auth_mysql.pbkdf2_derivedLength", [
+  {datatype, integer}
 ]}.
 
 {mapping, "auth.mysql.super_query", "emq_auth_mysql.super_query", [

--- a/src/emq_auth_mysql.erl
+++ b/src/emq_auth_mysql.erl
@@ -51,6 +51,10 @@ check(Client, Password, #state{auth_query  = {AuthSql, AuthParams},
 
 check_pass(PassHash, Password, HashType) ->
     check_pass(PassHash, hash(HashType, Password)).
+check_pass(PassHash, Salt, Password, {salt, pbkdf2}) ->
+    check_pass(PassHash, hash(HashType, {Salt, Password}));
+check_pass(PassHash, Salt, Password, {pbkdf2, salt}) ->
+    check_pass(PassHash, hash(HashType, {Salt, Password}));        
 check_pass(PassHash, Salt, Password, {salt, HashType}) ->
     check_pass(PassHash, hash(HashType, <<Salt/binary, Password/binary>>));
 check_pass(PassHash, Salt, Password, {HashType, salt}) ->

--- a/src/emq_pbkdf2.erl
+++ b/src/emq_pbkdf2.erl
@@ -1,0 +1,179 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(emq_pbkdf2).
+
+-export([pbkdf2/1, pbkdf2/5, compare_secure/2, to_hex/1]).
+
+
+%-type(hex_char() :: $0 .. $9 | $a .. $f).
+-type(hex_char() :: 48 .. 57 | 97 .. 102).
+-type(hex_list() :: [hex_char()]).
+
+
+-type digest_func_info() :: md4 | md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512.
+
+-type mac_func_info() :: {hmac, digest_func_info()} | digest_func_info().
+
+
+-define(MAX_DERIVED_KEY_LENGTH, (1 bsl 32 - 1)).
+
+%==================
+% Public API
+%==================
+-spec pbkdf2(Password) -> Key | derived_key_too_long when
+	Password :: binary().
+
+pbkdf2(Password) ->
+	MacFunc1 = resolve_mac_func({hmac, sha256}),
+	{ok, Iterations} = application:get_env(?APP, pbkdf2_iterations),
+	{ok, DerivedLength} = application:get_env(?APP, pbkdf2_derivedLength),
+	Bin = pbkdf2(MacFunc1, Password, Salt, Iterations, DerivedLength, 1, []),
+	Bin.
+
+
+-spec to_hex(Data) -> HexData when
+	Data :: binary() | list(),
+	HexData :: binary() | hex_list().
+
+to_hex(<<>>) ->
+	<<>>;
+
+to_hex(<<Char:8/integer, Rest/binary>>) ->
+	CharHex1 = to_hex_digit(Char div 16),
+	CharHex2 = to_hex_digit(Char rem 16),
+	RestHex = to_hex(Rest),
+	<<CharHex1, CharHex2, RestHex/binary>>;
+
+to_hex([]) ->
+	[];
+
+to_hex([Char | Rest]) ->
+	[to_hex_digit(Char div 16), to_hex_digit(Char rem 16) | to_hex(Rest)].
+
+%======================================================================================================================
+% Internal Functions
+
+-spec pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex, Acc) -> Key | derived_key_too_long when
+	MacFunc :: fun((binary(), binary()) -> binary()),
+	Password :: binary(),
+	Salt :: binary(),
+	Iterations :: integer(),
+	DerivedLength :: integer(),
+	BlockIndex :: integer(),
+	Acc :: iolist(),
+	Key :: binary().
+
+pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex, Acc) when DerivedLength > ?MAX_DERIVED_KEY_LENGTH ->
+	derived_key_too_long.
+
+pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex, Acc) ->
+	case iolist_size(Acc) > DerivedLength of
+		true ->
+			<<Bin:DerivedLength/binary, _/binary>> = iolist_to_binary(lists:reverse(Acc)),
+			Bin;
+		false ->
+			Block = pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, 1, <<>>, <<>>),
+			pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex + 1, [Block | Acc])
+	end.
+
+%----------------------------------------------------------------------------------------------------------------------
+
+-spec pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, Iteration, Prev, Acc) -> Key when
+	MacFunc :: fun((binary(), binary()) -> binary()),
+	Password :: binary(),
+	Salt :: binary(),
+	Iterations :: integer(),
+	BlockIndex :: integer(),
+	Iteration :: integer(),
+	Prev :: binary(),
+	Acc :: binary(),
+	Key :: binary().
+
+pbkdf2(_MacFunc, _Password, _Salt, Iterations, _BlockIndex, Iteration, _Prev, Acc) when Iteration > Iterations ->
+	Acc;
+
+pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, 1, _Prev, _Acc) ->
+	InitialBlock = MacFunc(Password, <<Salt/binary, BlockIndex:32/integer>>),
+	pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, 2, InitialBlock, InitialBlock);
+
+pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, Iteration, Prev, Acc) ->
+	Next = MacFunc(Password, Prev),
+	pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, Iteration + 1, Next, crypto:exor(Next, Acc)).
+
+%----------------------------------------------------------------------------------------------------------------------
+
+%-type mac_func_info() :: mac_func() | {hmac, digest_func_info()}
+%	| md4 | md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512.
+
+resolve_mac_func({hmac, DigestFunc}) ->
+	fun(Key, Data) ->
+		%crypto:hmac(DigestFunc, Key, Data)
+		HMAC = crypto:hmac_init(DigestFunc, Key),
+		HMAC1 = crypto:hmac_update(HMAC, Data),
+		crypto:hmac_final(HMAC1)
+	end;
+
+resolve_mac_func(MacFunc) when is_function(MacFunc) ->
+	MacFunc;
+
+resolve_mac_func(md4) -> resolve_mac_func({hmac, md4});
+resolve_mac_func(md5) -> resolve_mac_func({hmac, md5});
+resolve_mac_func(ripemd160) -> resolve_mac_func({hmac, ripemd160});
+resolve_mac_func(sha) -> resolve_mac_func({hmac, sha});
+resolve_mac_func(sha224) -> resolve_mac_func({hmac, sha224});
+resolve_mac_func(sha256) -> resolve_mac_func({hmac, sha256});
+resolve_mac_func(sha384) -> resolve_mac_func({hmac, sha384});
+resolve_mac_func(sha512) -> resolve_mac_func({hmac, sha512}).
+
+%----------------------------------------------------------------------------------------------------------------------
+
+%% Compare two strings or binaries for equality without short-circuits to avoid timing attacks.
+
+-spec compare_secure(First, Second) -> boolean() when
+	First :: binary() | string(),
+	Second :: binary() | string().
+
+compare_secure(<<X/binary>>, <<Y/binary>>) ->
+	compare_secure(binary_to_list(X), binary_to_list(Y));
+
+compare_secure(X, Y) when is_list(X) and is_list(Y) ->
+	case length(X) == length(Y) of
+		true ->
+			compare_secure(X, Y, 0);
+		false ->
+			false
+	end;
+
+compare_secure(_X, _Y) -> false.
+
+-spec compare_secure(First, Second, Accum) -> boolean() when
+	First :: string(),
+	Second :: string(),
+	Accum :: integer().
+
+compare_secure([X|RestX], [Y|RestY], Result) ->
+	compare_secure(RestX, RestY, (X bxor Y) bor Result);
+
+compare_secure([], [], Result) ->
+	Result == 0.
+
+%----------------------------------------------------------------------------------------------------------------------
+
+-spec to_hex_digit(Nyble) -> hex_char() when
+	Nyble :: 0 .. 15.
+
+to_hex_digit(N) when N < 10 ->
+	$0 + N;
+
+to_hex_digit(N) ->
+	$a + N - 10.

--- a/src/emq_pbkdf2.erl
+++ b/src/emq_pbkdf2.erl
@@ -33,7 +33,7 @@
 -spec pbkdf2(Password) -> Key | derived_key_too_long when
 	Password :: binary().
 
-pbkdf2(Password) ->
+pbkdf2({Salt,Password}) ->
 	MacFunc1 = resolve_mac_func({hmac, sha256}),
 	{ok, Iterations} = application:get_env(?APP, pbkdf2_iterations),
 	{ok, DerivedLength} = application:get_env(?APP, pbkdf2_derivedLength),

--- a/src/emq_pbkdf2.erl
+++ b/src/emq_pbkdf2.erl
@@ -12,26 +12,24 @@
 
 -module(emq_pbkdf2).
 
--export([pbkdf2/1, pbkdf2/5, compare_secure/2, to_hex/1]).
+-include("emq_auth_mysql.hrl").
+
+-export([pbkdf2/1, compare_secure/2, to_hex/1]).
 
 
 %-type(hex_char() :: $0 .. $9 | $a .. $f).
 -type(hex_char() :: 48 .. 57 | 97 .. 102).
 -type(hex_list() :: [hex_char()]).
 
-
--type digest_func_info() :: md4 | md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512.
-
--type mac_func_info() :: {hmac, digest_func_info()} | digest_func_info().
-
-
 -define(MAX_DERIVED_KEY_LENGTH, (1 bsl 32 - 1)).
 
 %==================
 % Public API
 %==================
--spec pbkdf2(Password) -> Key | derived_key_too_long when
-	Password :: binary().
+-spec pbkdf2({Slat,Password}) -> Key | derived_key_too_long when
+        Slat     :: binary(),
+        Password :: binary(),
+        Key      :: binary().
 
 pbkdf2({Salt,Password}) ->
 	MacFunc1 = resolve_mac_func({hmac, sha256}),
@@ -73,8 +71,9 @@ to_hex([Char | Rest]) ->
 	Acc :: iolist(),
 	Key :: binary().
 
-pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex, Acc) when DerivedLength > ?MAX_DERIVED_KEY_LENGTH ->
-	derived_key_too_long.
+pbkdf2(_MacFunc, _Password, _Salt, _Iterations, DerivedLength, _BlockIndex, _Acc) when DerivedLength > ?MAX_DERIVED_KEY_LENGTH ->
+	derived_key_too_long;
+
 
 pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex, Acc) ->
 	case iolist_size(Acc) > DerivedLength of


### PR DESCRIPTION
change the emq_auth_mysql.conf like this:
## Password hash: plain, md5, sha, sha256, pbkdf2
auth.mysql.password_hash = pbkdf2

## pbkdf2 Iterations and DerivedLength
auth.mysql.pbkdf2_iterations = 4096
auth.mysql.pbkdf2_derivedLength = 20